### PR TITLE
Add timestamp to ice payload.

### DIFF
--- a/src/turn.erl
+++ b/src/turn.erl
@@ -586,7 +586,7 @@ send_payload_to_parent(State, Payload) ->
                 {ice_controlling, StunMsg#stun.'ICE-CONTROLLING'}],
                self()};
         {Parent, false} ->
-            Parent ! {ice_payload, Payload}
+            Parent ! {ice_payload, Payload, get_timestamp()}
     end,
     NewState.
 


### PR DESCRIPTION
Add timestamp in order to generate average buffer processing time metric.

PR in ICE plugin: https://github.com/jellyfish-dev/membrane_ice_plugin/pull/26
issue: https://membraneframework.atlassian.net/jira/software/c/projects/RTC/boards/18?modal=detail&selectedIssue=RTC-98