### PR TITLE
Enable reuseaddr so restarting the server does not lead to port conflicts

### DIFF
--- a/src/stun_listener.erl
+++ b/src/stun_listener.erl
@@ -131,7 +131,7 @@ start_listener(IP, ClientPort, {MinPort, MaxPort}, Transport, Opts, Owner)
                            {ip, IP},
                            {packet, 0},
                            {active, false},
-                           {reuseaddr, false},
+                           {reuseaddr, true},
                            {nodelay, true},
                            {keepalive, true},
                            {send_timeout, ?TCP_SEND_TIMEOUT},
@@ -166,7 +166,7 @@ start_listener(IP, ClientPort, {MinPort, MaxPort}, udp, Opts, Owner) ->
             {active, false},
             {recbuf, ?UDP_RECBUF},
             {read_packets, ?UDP_READ_PACKETS}, 
-            {reuseaddr, false}])
+            {reuseaddr, true}])
         end,
     PortInfo =
         if ClientPort == undefined ->


### PR DESCRIPTION
I noticed restarting Jellyfish with active connections causes an error of :eaddrinuse given open connections remain in TIME_WAIT based upon the kernel timeouts. This PR enables SO_REUSEADDR on the sockets so that a restart will not have a port conflict when binding to the TURN port(s).